### PR TITLE
Switch to a non-biomolecule-centric subtitle for the MFFI

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -71,7 +71,7 @@ resources:
 </div>
 
 <h1 style="font-size: 2.6em; color: #2d5c80; text-align: center;"> Welcome to the Martini Force Field Initiative </h1>
-<h5 style="font-size: 1.6em; color: #2d5c80; text-align: center;"> A general purpose coarse-grained force field for biomolecular simulations </h5>
+<h5 style="font-size: 1.6em; color: #2d5c80; text-align: center;"> A general purpose force field for coarse-grained molecular dynamics </h5>
 
 <div class="buttons">
 <button href="#" class="btn-21" onclick="scrollToElement('.learn-more'); return false;"> <span> Learn more </span> </button>


### PR DESCRIPTION
In the homepage, why not use as the subtitle to MFFI:

> A general purpose force field for coarse-grained molecular dynamics

(which is from the Nat. Methods paper); or, alternatively:

> A general purpose coarse-grained force field for (bio)molecular simulations

The rationale behind this is that, while the majority of Martini applications remain in the biomolecular domain, both we and the broader Martini community now extensively apply it to non-biomolecular systems as well.

This PR addresses this update.