### PR TITLE
Add "forcefield" category to `Alessandri2022_SmallMolecules.qmd`

### DIFF
--- a/docs/publications/entries/2022/Alessandri2022_SmallMolecules.qmd
+++ b/docs/publications/entries/2022/Alessandri2022_SmallMolecules.qmd
@@ -12,6 +12,7 @@ materials: "https://onlinelibrary.wiley.com/action/downloadSupplement?doi=10.100
 categories:        # (required) these keywords will create tags for further filtering. 
   - Journal article
   - Small molecules
+  - Forcefield
   - Protocol
   - Parametrization
 ---


### PR DESCRIPTION
I think the small molecule paper should also be in the `Forcefield` category (as done for "Martini 3 Coarse-Grained Force Field for Carbohydrates"). This PR fixes that.