### PR TITLE
fix links in polyply tutorial

### DIFF
--- a/docs/tutorials/Martini3/Polyply/index.qmd
+++ b/docs/tutorials/Martini3/Polyply/index.qmd
@@ -25,7 +25,7 @@ This tutorial has three independent parts. It is recommended to start with part 
 
 In this tutorial you will learn how to generate simple polymer melts and blends with `polyply` using Martini3. It takes about 10min to complete the Tutorial and covers the basic functionality of `polyply` `.itp` file generation and coordinate generation. No prior knowledge is required to start this tutorial, but it is useful as background for the other two tutorials. Follow the link to get to the tutorial:
 
-* [https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-martini-polymer-melts:-martini-polymer-melts](https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-martini-polymer-melts:-martini-polymer-melts)
+* [https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-martini-polymer-melts](https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-martini-polymer-melts)
 
 ![](fig1.png)
 
@@ -34,7 +34,7 @@ In this tutorial you will learn how to generate simple polymer melts and blends 
 
 In this tutorial you will learn how to generate PEGylated lipid bilayers. It serves as an example tp explains how to connect a biomolecule to a polymer, build brushes, use pre-build coordinates from other programs. Follow the link to get to the tutorial:
 
-* [https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-PEGylated-lipid-bilayers:-PEGylated-lipid-bilayers](https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-PEGylated-lipid-bilayers:-PEGylated-lipid-bilayers)
+* [https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-PEGylated-lipid-bilayers](https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-PEGylated-lipid-bilayers)
 
 ![](fig2.png)
 


### PR DESCRIPTION
Fix links in polyply tutorial.
Old links lead to creation of wiki pages in the polyply wiki (instead of leading to the actual pages)