### PR TITLE
Changed registration deadline for Martini workshop in the announcement

### DIFF
--- a/docs/announcements/posts/2025-05-26-workshop-registration/index.qmd
+++ b/docs/announcements/posts/2025-05-26-workshop-registration/index.qmd
@@ -35,6 +35,6 @@ The application form contains a number of required fields to be filled out. Amon
 
 The number of participants is limited to 40, and in principle, you will be invited on a first-come-first-serve basis. So do not wait too long to apply! However, we might limit the number of participants from the same lab. After we receive and approve your application, we will send an invitation letter including payment details, and you are guaranteed a place if you pay the registration fee before the advertised deadline.
 
-**APPLICATION CLOSES** June 15, 2025, or earlier when full.
+**APPLICATION CLOSES** when workshop is full. ONLY A FEW SPACES REMAIN
 
 **Correspondence:** All queries/questions/remarks must be sent by email to [martiniworkshop2025@rug.nl](mailto:martiniworkshop2025@rug.nl).


### PR DESCRIPTION
Removed the workshop deadline from the announcement. The pdf that is opened still has the wrong date, but I will contact SJ about getting a modified version to upload.

Thanks!