### PR TITLE
Small fixes small molecule tutorial(s)

### DIFF
--- a/docs/tutorials/Martini3/Small_Molecule_Parametrization_Bartender/index.qmd
+++ b/docs/tutorials/Martini3/Small_Molecule_Parametrization_Bartender/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Parametrization of a new small molecule"
+title: "Parametrization of a new small molecule using Bartender"
 format: html
 ---
 


### PR DESCRIPTION
Even though I just merged the PR, I noticed the title on the new Bartender small mol tutorial doesn't say "using Bartender"... fixing this here.
